### PR TITLE
fix: enable Realsense rviz display and wire D435i mounts for bookstore/warehouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ detector/*.pt
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+# Beads archive (migrated to Jira 2026-04-13)
+.beads-archive.zip

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,6 +119,7 @@ services:
       ros2 launch tb_worlds tb_demo_world.launch.py
       world_name:=house_world.sdf.xacro
       map:=/overlay_ws/install/tb_worlds/share/tb_worlds/maps/house_world_map.yaml
+      rviz_config_file:=/overlay_ws/install/tb_worlds/share/tb_worlds/rviz/nav2_turtlebot_view.rviz
 
   # Bookstore world — AWS RoboMaker Bookstore (Gazebo Harmonic-compatible)
   # Uses the same overlay image as all other worlds; no rebuild needed.
@@ -128,6 +129,10 @@ services:
     environment:
       - GZ_SIM_RESOURCE_PATH=/overlay_ws/install/tb_worlds/share/tb_worlds/worlds:/overlay_ws/install/tb_worlds/share/tb_worlds/models
     volumes:
+      # D435i camera config (bridge + URDF + rviz) — same as demo-world-enhanced / demo-world-house
+      - ./tb_worlds/configs/turtlebot3_bridge.yaml:/overlay_ws/install/tb_worlds/share/tb_worlds/configs/turtlebot3_bridge.yaml:ro
+      - ./tb_worlds/urdf/gz_waffle.sdf.xacro:/overlay_ws/install/tb_worlds/share/tb_worlds/urdf/gz_waffle.sdf.xacro:ro
+      - ./tb_worlds/rviz/nav2_turtlebot_view.rviz:/overlay_ws/install/tb_worlds/share/tb_worlds/rviz/nav2_turtlebot_view.rviz:ro
       # Inject new world files without rebuilding the overlay image.
       - ./tb_worlds/worlds/bookstore_world.sdf.xacro:/overlay_ws/install/tb_worlds/share/tb_worlds/worlds/bookstore_world.sdf.xacro:ro
       - ./tb_worlds/maps/bookstore_world_map.pgm:/overlay_ws/install/tb_worlds/share/tb_worlds/maps/bookstore_world_map.pgm:ro
@@ -137,6 +142,7 @@ services:
       ros2 launch tb_worlds tb_demo_world.launch.py
       world_name:=bookstore_world.sdf.xacro
       map:=/overlay_ws/install/tb_worlds/share/tb_worlds/maps/bookstore_world_map.yaml
+      rviz_config_file:=/overlay_ws/install/tb_worlds/share/tb_worlds/rviz/nav2_turtlebot_view.rviz
 
   # Warehouse world — AWS RoboMaker Small Warehouse, no-roof variant (Jazzy-compatible)
   # Uses the same overlay image as all other worlds; no rebuild needed.
@@ -146,6 +152,10 @@ services:
     environment:
       - GZ_SIM_RESOURCE_PATH=/overlay_ws/install/tb_worlds/share/tb_worlds/worlds:/overlay_ws/install/tb_worlds/share/tb_worlds/models
     volumes:
+      # D435i camera config (bridge + URDF + rviz) — same as demo-world-enhanced / demo-world-house
+      - ./tb_worlds/configs/turtlebot3_bridge.yaml:/overlay_ws/install/tb_worlds/share/tb_worlds/configs/turtlebot3_bridge.yaml:ro
+      - ./tb_worlds/urdf/gz_waffle.sdf.xacro:/overlay_ws/install/tb_worlds/share/tb_worlds/urdf/gz_waffle.sdf.xacro:ro
+      - ./tb_worlds/rviz/nav2_turtlebot_view.rviz:/overlay_ws/install/tb_worlds/share/tb_worlds/rviz/nav2_turtlebot_view.rviz:ro
       # Inject new world files without rebuilding the overlay image.
       - ./tb_worlds/worlds/warehouse_world.sdf.xacro:/overlay_ws/install/tb_worlds/share/tb_worlds/worlds/warehouse_world.sdf.xacro:ro
       - ./tb_worlds/maps/warehouse_world_map.pgm:/overlay_ws/install/tb_worlds/share/tb_worlds/maps/warehouse_world_map.pgm:ro
@@ -155,6 +165,7 @@ services:
       ros2 launch tb_worlds tb_demo_world.launch.py
       world_name:=warehouse_world.sdf.xacro
       map:=/overlay_ws/install/tb_worlds/share/tb_worlds/maps/warehouse_world_map.yaml
+      rviz_config_file:=/overlay_ws/install/tb_worlds/share/tb_worlds/rviz/nav2_turtlebot_view.rviz
 
   # Behavior demo using Python and py_trees
   demo-behavior-py:

--- a/tb_worlds/rviz/nav2_turtlebot_view.rviz
+++ b/tb_worlds/rviz/nav2_turtlebot_view.rviz
@@ -510,7 +510,7 @@ Visualization Manager:
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
-      Enabled: false
+      Enabled: true
       Name: Realsense
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true


### PR DESCRIPTION
## Summary

Resolves **AURA-631 / AURA-632** — RViz2 `RealsenseCamera` panel showed "No Image" in `demo-world-{house,bookstore,warehouse}` despite topics publishing.

Root cause:
- `Realsense` display group in `nav2_turtlebot_view.rviz` was `Enabled: false`.
- Bookstore and warehouse compose services were not bind-mounting the D435i bridge/URDF/rviz overrides, and not passing `rviz_config_file:=...` to the launch file, so the baked-in overlay image loaded a stale rviz config with dead R200 topics.

## Changes

- Enable the `Realsense` display group in `tb_worlds/rviz/nav2_turtlebot_view.rviz`.
- Pass \`rviz_config_file:=/overlay_ws/install/tb_worlds/share/tb_worlds/rviz/nav2_turtlebot_view.rviz\` to \`demo-world-house\`, \`demo-world-bookstore\`, and \`demo-world-warehouse\`.
- Bind-mount \`turtlebot3_bridge.yaml\`, \`gz_waffle.sdf.xacro\`, and \`nav2_turtlebot_view.rviz\` into the bookstore and warehouse services (house already had them).
- Ignore \`.beads-archive.zip\` (beads→Jira migration artifact).

## Related Jira

- AURA-631 — RViz2 RealsenseCamera shows "No Image" in demo-world-house
- AURA-632 — Same regression in bookstore / warehouse

## Test plan

- [ ] \`docker compose up demo-world-house\` — RViz shows live 320×240 RGB frames from the simulated D435i
- [ ] \`docker compose up demo-world-bookstore\` — same
- [ ] \`docker compose up demo-world-warehouse\` — same
- [ ] \`pre-commit run -a\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)